### PR TITLE
set raw files indexed to false when creating bundle

### DIFF
--- a/broker/dssapi.py
+++ b/broker/dssapi.py
@@ -37,7 +37,7 @@ class DssApi:
             submittedName = file["submittedName"]
             url = file["url"]
             uuid = file["dss_uuid"]
-
+            indexed = file["indexed"]
             if not url:
                 self.logger.warn("can't create bundle for "+submittedName+" as no cloud URL is provided")
                 continue
@@ -52,7 +52,7 @@ class DssApi:
                 self.logger.debug("Bundle file submited "+url)
                 version = json.loads(r.text)["version"]
                 fileObject = {
-                    "indexed": True,
+                    "indexed": indexed,
                     "name": submittedName,
                     "uuid": uuid,
                     "version": version

--- a/broker/ingestexportservice.py
+++ b/broker/ingestexportservice.py
@@ -137,7 +137,7 @@ class IngestExporter:
                 projectDssUuid = unicode(uuid.uuid4())
                 projectFileName = "project_"+str(index)+".json"
                 fileDescription = self.writeMetadataToStaging(submissionEnvelopeUuid, projectFileName, projectBundle, "hca-project")
-                projectUuidToBundleData[projectUuid] = {"name":projectFileName,"submittedName":"project.json", "url":fileDescription.url, "dss_uuid": projectDssUuid}
+                projectUuidToBundleData[projectUuid] = {"name":projectFileName,"submittedName":"project.json", "url":fileDescription.url, "dss_uuid": projectDssUuid, "indexed": True}
 
                 bundleManifest.fileProjectMap = {projectDssUuid: [projectUuid]}
             else:
@@ -162,7 +162,7 @@ class IngestExporter:
                 sampleDssUuid = unicode(uuid.uuid4())
                 sampleFileName = "sample_"+str(index)+".json"
                 fileDescription = self.writeMetadataToStaging(submissionEnvelopeUuid, sampleFileName, sampleBundle, "hca-sample")
-                sampleUuidToBundleData[sampleUuid] = {"name":sampleFileName, "submittedName":"sample.json", "url":fileDescription.url, "dss_uuid": sampleDssUuid}
+                sampleUuidToBundleData[sampleUuid] = {"name":sampleFileName, "submittedName":"sample.json", "url":fileDescription.url, "dss_uuid": sampleDssUuid, "indexed": True}
                 bundleManifest.fileSampleMap = {sampleDssUuid: sampleRelatedUuids}
             else:
                 bundleManifest.fileSampleMap = {sampleUuidToBundleData[sampleUuid]["dss_uuid"]: sampleRelatedUuids}
@@ -174,7 +174,7 @@ class IngestExporter:
                 fileUuid = file["uuid"]["uuid"]
                 fileName = file["fileName"]
                 cloudUrl = file["cloudUrl"]
-                fileToBundleData[fileUuid] = {"name":fileName, "submittedName":fileName, "url":cloudUrl, "dss_uuid": fileUuid}
+                fileToBundleData[fileUuid] = {"name":fileName, "submittedName":fileName, "url":cloudUrl, "dss_uuid": fileUuid, "indexed": False}
                 submittedFiles.append(fileToBundleData[fileUuid])
                 bundleManifest.files.append(fileUuid)
 
@@ -185,7 +185,7 @@ class IngestExporter:
 
             fileDescription = self.writeMetadataToStaging(submissionEnvelopeUuid, assayFileName, assaysBundle, "hca-assay")
             bundleManifest.fileAssayMap = {assayDssUuid: [assayUuid]}
-            submittedFiles.append({"name":assayFileName, "submittedName":"assay.json", "url":fileDescription.url, "dss_uuid": assayDssUuid})
+            submittedFiles.append({"name":assayFileName, "submittedName":"assay.json", "url":fileDescription.url, "dss_uuid": assayDssUuid, "indexed": True})
 
             self.logger.info("All files staged...")
 


### PR DESCRIPTION
@rolando-ebi here's a fix to set raw files to not be indexed when submitting to the dss. Once you've merged in here you'll need to pull these changes into the ingest-exporter submodule where they are actually needed.