### PR TITLE
Converter and exporter now take optional argument -v for metadata sch…

### DIFF
--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -65,7 +65,7 @@ class SpreadsheetSubmission:
         self.dryrun = dry
         self.outputDir = output
         self.ingest_api = None
-        self.schema_version = schema_version if schema_version else SCHEMA_VERSION
+        self.schema_version = schema_version if schema_version else os.path.expandvars(SCHEMA_VERSION)
         self.schema_url = os.path.expandvars(SCHEMA_URL % self.schema_version)
         if not self.dryrun:
             self.ingest_api = IngestApi()

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -50,9 +50,9 @@ v4_timeFields = {"immortalized_cell_line" : ["date_established"],
 
 v4_stringFields = {"donor" : ["age", "weight", "height"]}
 
-SCHEMA_URL = "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/"
+SCHEMA_URL = os.environ.get('SCHEMA_URL', "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/")
 # SCHEMA_URL = os.path.expandvars(os.environ.get('SCHEMA_URL', SCHEMA_URL))
-SCHEMA_VERSION = '4.4.0'
+SCHEMA_VERSION = os.environ.get('SCHEMA_VERSION', '4.4.0')
 
 
 class SpreadsheetSubmission:
@@ -66,7 +66,7 @@ class SpreadsheetSubmission:
         self.outputDir = output
         self.ingest_api = None
         self.schema_version = schema_version if schema_version else SCHEMA_VERSION
-        self.schema_url = os.path.expandvars(os.environ.get('SCHEMA_URL', SCHEMA_URL % self.schema_version))
+        self.schema_url = os.path.expandvars(SCHEMA_URL % self.schema_version)
         if not self.dryrun:
             self.ingest_api = IngestApi()
 

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -50,12 +50,14 @@ v4_timeFields = {"immortalized_cell_line" : ["date_established"],
 
 v4_stringFields = {"donor" : ["age", "weight", "height"]}
 
-SCHEMA_URL = "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/"
-SCHEMA_URL = os.path.expandvars(os.environ.get('SCHEMA_URL', SCHEMA_URL))
+SCHEMA_URL = "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/"
+# SCHEMA_URL = os.path.expandvars(os.environ.get('SCHEMA_URL', SCHEMA_URL))
+SCHEMA_VERSION = '4.4.0'
+
 
 class SpreadsheetSubmission:
 
-    def __init__(self, dry=False, output=None):
+    def __init__(self, dry=False, output=None, schema_version=None):
         # formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
         # logging.basicConfig(formatter=formatter, level=logging.INFO)
         self.logger = logging.getLogger(__name__)
@@ -63,6 +65,8 @@ class SpreadsheetSubmission:
         self.dryrun = dry
         self.outputDir = output
         self.ingest_api = None
+        self.schema_version = schema_version if schema_version else SCHEMA_VERSION
+        self.schema_url = os.path.expandvars(os.environ.get('SCHEMA_URL', SCHEMA_URL % self.schema_version))
         if not self.dryrun:
             self.ingest_api = IngestApi()
 
@@ -358,7 +362,9 @@ class SpreadsheetSubmission:
                 cont.append(contributor)
             project["contributors"] = cont
 
-            project["core"] = {"type": "project", "schema_url": SCHEMA_URL + "project.json"}
+            project["core"] = {"type": "project",
+                               "schema_url": self.schema_url + "project.json",
+                               "schema_version": self.schema_version}
 
             self.dumpJsonToFile(project, projectId, "project")
 
@@ -382,7 +388,9 @@ class SpreadsheetSubmission:
             if "protocol_id" not in protocol:
                 raise ValueError('Protocol must have an id attribute')
 
-            protocol["core"] = {"type": "protocol", "schema_url": SCHEMA_URL + "protocol.json"}
+            protocol["core"] = {"type": "protocol",
+                                "schema_url": self.schema_url + "protocol.json",
+                               "schema_version": self.schema_version}
             self.dumpJsonToFile(protocol, projectId, "protocol_" + str(index))
             protocolMap[protocol["protocol_id"]] = protocol
             if not self.dryrun:
@@ -431,7 +439,9 @@ class SpreadsheetSubmission:
                 sampleProtocols = donor["protocol_ids"]
                 del donor["protocol_ids"]
 
-            donor["core"] = {"type" : "sample", "schema_url": SCHEMA_URL + "sample.json"}
+            donor["core"] = {"type" : "sample",
+                             "schema_url": self.schema_url + "sample.json",
+                            "schema_version": self.schema_version}
 
             self.dumpJsonToFile(donor, projectId, "donor_" + str(index))
             if not self.dryrun:
@@ -502,7 +512,9 @@ class SpreadsheetSubmission:
                     sampleProtocols = sample["protocol_ids"]
                     del sample["protocol_ids"]
 
-                sample["core"] = {"type" : "sample", "schema_url": SCHEMA_URL + "sample.json"}
+                sample["core"] = {"type" : "sample",
+                                  "schema_url": self.schema_url + "sample.json",
+                                "schema_version": self.schema_version}
 
                 self.dumpJsonToFile(sample, projectId, "sample_" + str(index))
                 if not self.dryrun:
@@ -667,7 +679,9 @@ class SpreadsheetSubmission:
                 assayMap[assay]["seq"]["insdc_run"] = []
                 assayMap[assay]["seq"]["insdc_run"].append(seqFile["insdc_run"])
 
-            file["core"] = {"type" : "file", "schema_url": SCHEMA_URL + "file.json"}
+            file["core"] = {"type" : "file",
+                            "schema_url": self.schema_url + "file.json",
+                           "schema_version": self.schema_version}
 
             self.dumpJsonToFile(file, projectId, "files_" + str(index))
             if not self.dryrun:
@@ -699,7 +713,9 @@ class SpreadsheetSubmission:
             samples = assay["sample_id"]
             del assay["sample_id"]
 
-            assay["core"] = {"type" : "assay", "schema_url": SCHEMA_URL + "assay.json"}
+            assay["core"] = {"type" : "assay",
+                             "schema_url": self.schema_url + "assay.json",
+                             "schema_version": self.schema_version}
             self.dumpJsonToFile(assay, projectId, "assay_" + str(index))
 
             if not self.dryrun:
@@ -734,10 +750,12 @@ if __name__ == '__main__':
                       help="output directory where to dump json files submitted to ingest", metavar="FILE", default=None)
     parser.add_option("-i", "--id", dest="project_id",
                       help="The project_id for an existing submission", default=None)
+    parser.add_option("-v", "--version", dest="schema_version", help="Metadata schema version", default=None)
+
 
     (options, args) = parser.parse_args()
     if not options.path:
         print ("You must supply path to the HCA bundles directory")
         exit(2)
-    submission = SpreadsheetSubmission(options.dry, options.output)
+    submission = SpreadsheetSubmission(options.dry, options.output, options.schema_version)
     submission.submit(options.path, None, options.project_id)

--- a/broker/ingestexportservice.py
+++ b/broker/ingestexportservice.py
@@ -21,8 +21,8 @@ DEFAULT_INGEST_URL=os.environ.get('INGEST_API', 'http://api.ingest.dev.data.huma
 DEFAULT_STAGING_URL=os.environ.get('STAGING_API', 'http://staging.dev.data.humancellatlas.org')
 DEFAULT_DSS_URL=os.environ.get('DSS_API', 'http://dss.dev.data.humancellatlas.org')
 
-BUNDLE_SCHEMA_BASE_URL='https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/'
-METADATA_SCHEMA_VERSION = '4.4.0'
+BUNDLE_SCHEMA_BASE_URL=os.environ.get('BUNDLE_SCHEMA_BASE_URL', 'https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/')
+METADATA_SCHEMA_VERSION = os.environ.get('SCHEMA_VERSION', '4.4.0')
 
 
 class IngestExporter:
@@ -37,8 +37,8 @@ class IngestExporter:
         self.ingestUrl = options.ingest if options and options.ingest else os.path.expandvars(DEFAULT_INGEST_URL)
         self.stagingUrl = options.staging if options and options.staging else os.path.expandvars(DEFAULT_STAGING_URL)
         self.dssUrl = options.dss if options and options.dss else os.path.expandvars(DEFAULT_DSS_URL)
-        self.schema_version = options.schema_version if options and options.schema_version else METADATA_SCHEMA_VERSION
-        self.schema_url = os.path.expandvars(os.environ.get('BUNDLE_SCHEMA_BASE_URL', BUNDLE_SCHEMA_BASE_URL % self.schema_version))
+        self.schema_version = options.schema_version if options and options.schema_version else os.path.expandvars(METADATA_SCHEMA_VERSION)
+        self.schema_url = os.path.expandvars(BUNDLE_SCHEMA_BASE_URL % self.schema_version)
 
         self.logger.debug("ingest url is "+self.ingestUrl)
 

--- a/broker/ingestexportservice.py
+++ b/broker/ingestexportservice.py
@@ -21,7 +21,9 @@ DEFAULT_INGEST_URL=os.environ.get('INGEST_API', 'http://api.ingest.dev.data.huma
 DEFAULT_STAGING_URL=os.environ.get('STAGING_API', 'http://staging.dev.data.humancellatlas.org')
 DEFAULT_DSS_URL=os.environ.get('DSS_API', 'http://dss.dev.data.humancellatlas.org')
 
-BUNDLE_SCHEMA_BASE_URL=os.environ.get('BUNDLE_SCHEMA_BASE_URL', 'https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/')
+BUNDLE_SCHEMA_BASE_URL='https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/%s/json_schema/'
+METADATA_SCHEMA_VERSION = '4.4.0'
+
 
 class IngestExporter:
     def __init__(self, options={}):
@@ -35,6 +37,9 @@ class IngestExporter:
         self.ingestUrl = options.ingest if options and options.ingest else os.path.expandvars(DEFAULT_INGEST_URL)
         self.stagingUrl = options.staging if options and options.staging else os.path.expandvars(DEFAULT_STAGING_URL)
         self.dssUrl = options.dss if options and options.dss else os.path.expandvars(DEFAULT_DSS_URL)
+        self.schema_version = options.schema_version if options and options.schema_version else METADATA_SCHEMA_VERSION
+        self.schema_url = os.path.expandvars(os.environ.get('BUNDLE_SCHEMA_BASE_URL', BUNDLE_SCHEMA_BASE_URL % self.schema_version))
+
         self.logger.debug("ingest url is "+self.ingestUrl)
 
         self.staging_api = StagingApi()
@@ -168,7 +173,9 @@ class IngestExporter:
 
             projectEntity = self.getBundleDocument(project)
             # add bundle schema reference
-            projectEntity["core"] = {"type" : "project_bundle", "schema_url": BUNDLE_SCHEMA_BASE_URL + "project_bundle.json"}
+            projectEntity["core"] = {"type" : "project_bundle",
+                                     "schema_url": self.schema_url + "project_bundle.json",
+                                     "schema_version": self.schema_version}
 
             if projectUuid not in projectUuidToBundleData:
                 projectDssUuid = unicode(uuid.uuid4())
@@ -200,7 +207,9 @@ class IngestExporter:
             nestedProtocols = self.getNestedObjects("protocols", sample, "protocols")
 
             sampleBundle = {}
-            sampleBundle["core"] = {"type": "sample_bundle", "schema_url": BUNDLE_SCHEMA_BASE_URL + "sample_bundle.json"}
+            sampleBundle["core"] = {"type": "sample_bundle",
+                                    "schema_url": self.schema_url + "sample_bundle.json",
+                                    "schema_version": self.schema_version}
             sampleBundle["samples"] = []
             primarySample = self.getBundleDocument(sample)
             primarySample["derivation_protocols"] = []
@@ -247,7 +256,9 @@ class IngestExporter:
 
             #TO DO: this is hack in v4 because the bundle schema is specified as an array rather than an object! this should be corrected in v5
             assayEntity = self.getBundleDocument(assay)
-            assayEntity["core"] = {"type": "assay_bundle", "schema_url": BUNDLE_SCHEMA_BASE_URL + "assay_bundle.json"}
+            assayEntity["core"] = {"type": "assay_bundle",
+                                   "schema_url": self.schema_url + "assay_bundle.json",
+                                   "schema_version": self.schema_version}
 
             assayDssUuid = unicode(uuid.uuid4())
             assayFileName = "assay_bundle_" + str(index) + ".json"
@@ -370,6 +381,7 @@ if __name__ == '__main__':
     parser.add_option("-s", "--staging", help="the URL to the staging API")
     parser.add_option("-d", "--dss", help="the URL to the datastore service")
     parser.add_option("-l", "--log", help="the logging level", default='INFO')
+    parser.add_option("-v", "--version", dest="schema_version", help="Metadata schema version", default=None)
 
     (options, args) = parser.parse_args()
     if not options.submissionsEnvelopeId:


### PR DESCRIPTION
…ema version to build version URLs dynamically

-v is None by default and there is still a default schema_version set as a global variable that is used if no -v is provided but we should aim to provide a schema version at all times.