### PR TITLE
Added example checks for presence of required fields in donor.json

### DIFF
--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -415,7 +415,7 @@ class SpreadsheetSubmission:
 
             if "donor" not in donor:
                 # Returns ValueError if there are no other donor.fields and donor.is_living is missing
-                raise ValueError('Sample of type donor must have a value for is_living')
+                raise ValueError('Field is_living for sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
             else:
                 if "is_living" in donor["donor"]:
                     if donor["donor"]["is_living"].lower()in ["true", "yes"]:
@@ -424,12 +424,16 @@ class SpreadsheetSubmission:
                         donor["donor"]["is_living"] = False
                     else:
                         # Returns ValueError if donor.is_living isn't true,yes,false,no
-                        raise ValueError('Field is_living in sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
+                        raise ValueError('Field is_living for sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
                 else:
                     # Returns ValueError if there are other donor.fields but donor.is_living is empty
-                    raise ValueError('Field is_living in sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
+                    raise ValueError('Field is_living for sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
 
-            if "ncbi_taxon_id" in donor and "genus_species" in donor:
+            if "ncbi_taxon_id" not in donor:
+                # Returns ValueError if donor.ncbi_taxon_id is empty
+                raise ValueError('Field ncbi_taxon_id for sample ' + sample_id + ' is a required field and must contain a valid NCBI Taxon ID')
+
+            if "genus_species" in donor:
                 donor["genus_species"]["ontology"] = "NCBITaxon:" + str(donor["ncbi_taxon_id"])
 
             if sample_id in deathMap.keys():
@@ -471,9 +475,15 @@ class SpreadsheetSubmission:
             if "sample_id" not in sample:
                 raise ValueError('Sample must have an id attribute')
             sampleMap[sample["sample_id"]] = sample
+            sample_id = donor["sample_id"]
 
-        if "ncbi_taxon_id" in sample and "genus_species" in sample:
-            sample["genus_species"]["ontology"] = "NCBITaxon:" + str(sample["ncbi_taxon_id"])
+            if "ncbi_taxon_id" not in sample:
+                # Returns ValueError if donor.ncbi_taxon_id is empty
+                raise ValueError(
+                    'Field ncbi_taxon_id for sample ' + sample_id + ' is a required field and must contain a valid NCBI Taxon ID')
+
+            if "genus_species" in sample:
+                sample["genus_species"]["ontology"] = "NCBITaxon:" + str(sample["ncbi_taxon_id"])
 
         # add dependent information to various sample types
         for state in specimen_state:

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -413,20 +413,21 @@ class SpreadsheetSubmission:
                 raise ValueError('Sample of type donor must have an id attribute')
             sample_id = donor["sample_id"]
 
-            # Check existence of all required fields
-            if "is_living" not in donor:
+            if "donor" not in donor:
+                # Returns ValueError if there are no other donor.fields and donor.is_living is missing
                 raise ValueError('Sample of type donor must have a value for is_living')
-
-            if "ncbi_taxon_id" not in donor:
-                raise ValueError('Sample of type donor must have a value for ncbi_taxon_id')
-
-            if "is_living" in donor["donor"]:
-                if donor["donor"]["is_living"].lower()in ["true", "yes"]:
-                    donor["donor"]["is_living"] = True
-                elif donor["donor"]["is_living"].lower() in ["false", "no"]:
-                    donor["donor"]["is_living"] = False
             else:
-                raise ValueError('Field is_living in sample ' + sample_id + ' must either contain one of yes, true, no or false')
+                if "is_living" in donor["donor"]:
+                    if donor["donor"]["is_living"].lower()in ["true", "yes"]:
+                        donor["donor"]["is_living"] = True
+                    elif donor["donor"]["is_living"].lower() in ["false", "no"]:
+                        donor["donor"]["is_living"] = False
+                    else:
+                        # Returns ValueError if donor.is_living isn't true,yes,false,no
+                        raise ValueError('Field is_living in sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
+                else:
+                    # Returns ValueError if there are other donor.fields but donor.is_living is empty
+                    raise ValueError('Field is_living in sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
 
             if "ncbi_taxon_id" in donor and "genus_species" in donor:
                 donor["genus_species"]["ontology"] = "NCBITaxon:" + str(donor["ncbi_taxon_id"])

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -413,6 +413,13 @@ class SpreadsheetSubmission:
                 raise ValueError('Sample of type donor must have an id attribute')
             sample_id = donor["sample_id"]
 
+            # Check existence of all required fields
+            if "is_living" not in donor:
+                raise ValueError('Sample of type donor must have a value for is_living')
+
+            if "ncbi_taxon_id" not in donor:
+                raise ValueError('Sample of type donor must have a value for ncbi_taxon_id')
+
             if "is_living" in donor["donor"]:
                 if donor["donor"]["is_living"].lower()in ["true", "yes"]:
                     donor["donor"]["is_living"] = True

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -422,9 +422,12 @@ class SpreadsheetSubmission:
                         donor["donor"]["is_living"] = True
                     elif donor["donor"]["is_living"].lower() in ["false", "no"]:
                         donor["donor"]["is_living"] = False
+                    '''
+                    # Commented out because we shouldn't be doing content validation in the converter
                     else:
                         # Returns ValueError if donor.is_living isn't true,yes,false,no
                         raise ValueError('Field is_living for sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')
+                    '''
                 else:
                     # Returns ValueError if there are other donor.fields but donor.is_living is empty
                     raise ValueError('Field is_living for sample ' + sample_id + ' is a required field and must either contain one of yes, true, no, or false')

--- a/broker/hcaxlsbroker.py
+++ b/broker/hcaxlsbroker.py
@@ -475,7 +475,7 @@ class SpreadsheetSubmission:
             if "sample_id" not in sample:
                 raise ValueError('Sample must have an id attribute')
             sampleMap[sample["sample_id"]] = sample
-            sample_id = donor["sample_id"]
+            sample_id = sample["sample_id"]
 
             if "ncbi_taxon_id" not in sample:
                 # Returns ValueError if donor.ncbi_taxon_id is empty


### PR DESCRIPTION
If a required metadata field is missing in the spreadsheet, converter fails and doesn't push the JSON through to validation. We need to find and display meaningful messages for ALL missing required fields as early as possible. This will ensure that we avoid wasting time doing conversions for files that will ultimately fail due to missing required fields.

This PR is an example set of lines that can be used to check for presence of the required fields `is_living` and `ncbi_taxon_id` in donor.json.