### PR TITLE
updating broker to pretty print JSON for metadata files on staging

### DIFF
--- a/broker/stagingapi.py
+++ b/broker/stagingapi.py
@@ -69,7 +69,7 @@ class StagingApi:
 
         header = dict(self.header)
         header['Content-type'] = 'application/json; dcp-type=' + type
-        r = requests.put(fileUrl,  data=json.dumps(body), headers=header)
+        r = requests.put(fileUrl,  data=json.dumps(body, indent=4), headers=header)
         if r.status_code == requests.codes.ok or requests.codes.created:
             responseObject = json.loads(r.text)
             return FileDescription(responseObject["checksums"],type,responseObject["name"],responseObject["size"],responseObject["url"], )


### PR DESCRIPTION
From Sam P:
> I have a feature request: please could Ingest produce formatted JSON when generating metadata files? When trying to debug metadata problems I navigate around the data store and then am confronted with a wall of JSON that I have to either download or save-to-file then format to be able to read.  The bundle manifests in the data store are formatted JSON which makes them much easier to read in a browser.

This one liner should solve fix this. But I haven't tested this at all, indeed I'm not sure how to test the code that does the export without deploying to dev.