### PR TITLE
Restructured spreadsheet file storage to only keep the latest

### DIFF
--- a/broker/brokerapi/broker_api.py
+++ b/broker/brokerapi/broker_api.py
@@ -207,13 +207,9 @@ def _check_token():
 
 def _save_file(submission_uuid):
     request_file = request.files['file']
-    filename = secure_filename(request_file.filename)
-
     spreadsheet_storage_service = SpreadsheetStorageService(
             SPREADSHEET_STORAGE_DIR)
-    path = spreadsheet_storage_service.store(submission_uuid,
-                                      filename,
-                                      request_file.read())
+    path = spreadsheet_storage_service.store(submission_uuid, request_file.read())
     logger.info("Saved file to: " + path)
     return path
 

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -1,5 +1,7 @@
 from os import path
 
+from broker.service.spreadsheet_storage.spreadsheet_storage_exceptions import \
+    SubmissionSpreadsheetDoesntExist
 from .spreadsheet_storage_exceptions import SubmissionSpreadsheetAlreadyExists
 
 
@@ -28,9 +30,12 @@ class SpreadsheetStorageService:
             raise SubmissionSpreadsheetAlreadyExists()
 
     def retrieve(self, submission_uuid):
-        file_path = path.join(self.storage_dir, f'{submission_uuid}.xlsx')
-        file_manifest = {'name': file_path}
-        with open(file_path, 'rb') as spreadsheet_file:
-            data = spreadsheet_file.read()
-            file_manifest['blob'] = data
-        return file_manifest
+        try:
+            file_path = path.join(self.storage_dir, f'{submission_uuid}.xlsx')
+            file_manifest = {'name': file_path}
+            with open(file_path, 'rb') as spreadsheet_file:
+                data = spreadsheet_file.read()
+                file_manifest['blob'] = data
+            return file_manifest
+        except FileNotFoundError:
+            raise SubmissionSpreadsheetDoesntExist()

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -11,15 +11,13 @@ class SpreadsheetStorageService:
         self.storage_dir = storage_dir
         self.storage_manifest_name = storage_manifest_name
 
-    # TODO remove spreadsheet_name
-    def store(self, submission_uuid, spreadsheet_name, spreadsheet_blob):
+    def store(self, submission_uuid, spreadsheet_blob):
         """
         Stores a given spreadsheet at path <submission_uuid>/<spreadsheetname>, local to
         the storage directory
-        :param submission_uuid:
-        :param spreadsheet_name:
-        :param spreadsheet_blob:
-        :return:
+        :param submission_uuid: the UUID for the spreadsheet submission
+        :param spreadsheet_blob: spreadsheet data in bytes
+        :return: the file path of the spreadsheet file in the storage
         """
         try:
             file_path = path.join(self.storage_dir, f'{submission_uuid}.xlsx')

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -1,5 +1,7 @@
 import os
 import json
+from os import path
+
 from .spreadsheet_storage_exceptions import SubmissionSpreadsheetAlreadyExists, SubmissionSpreadsheetDoesntExist
 
 
@@ -18,11 +20,17 @@ class SpreadsheetStorageService:
         :param spreadsheet_blob:
         :return:
         """
-        submission_dir = f'{self.storage_dir}/{submission_uuid}'
-        try:
+        submission_dir = path.join(self.storage_dir, submission_uuid)
+        if not path.exists(submission_dir):
             os.mkdir(submission_dir)
-            submission_spreadsheet_path = f'{submission_dir}/{spreadsheet_name}'
-            storage_manifest_path = f'{submission_dir}/{self.storage_manifest_name}'
+        try:
+            submission_spreadsheet_path = path.join(submission_dir, spreadsheet_name)
+            index = 0
+            while path.exists(submission_spreadsheet_path):
+                submission_spreadsheet_path = path.join(submission_dir,
+                                                        f'{spreadsheet_name}{index}.xlsx')
+                index += 1
+            storage_manifest_path = path.join(submission_dir, self.storage_manifest_name)
             with open(submission_spreadsheet_path, "wb") as spreadsheet_file:
                 spreadsheet_file.write(spreadsheet_blob)
                 with open(storage_manifest_path, "w") as storage_manfiest:

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -24,20 +24,24 @@ class SpreadsheetStorageService:
         if not path.exists(submission_dir):
             os.mkdir(submission_dir)
         try:
-            submission_spreadsheet_path = path.join(submission_dir, spreadsheet_name)
-            index = 0
-            while path.exists(submission_spreadsheet_path):
-                submission_spreadsheet_path = path.join(submission_dir,
-                                                        f'{spreadsheet_name}{index}.xlsx')
-                index += 1
+            file_path = self._determine_file_path(submission_dir, spreadsheet_name)
             storage_manifest_path = path.join(submission_dir, self.storage_manifest_name)
-            with open(submission_spreadsheet_path, "wb") as spreadsheet_file:
+            with open(file_path, "wb") as spreadsheet_file:
                 spreadsheet_file.write(spreadsheet_blob)
                 with open(storage_manifest_path, "w") as storage_manfiest:
-                    json.dump({"name": spreadsheet_name, "location": submission_spreadsheet_path}, storage_manfiest)
-                    return submission_spreadsheet_path
+                    json.dump({"name": spreadsheet_name, "location": file_path}, storage_manfiest)
+                    return file_path
         except FileExistsError:
             raise SubmissionSpreadsheetAlreadyExists()
+
+    @staticmethod
+    def _determine_file_path(submission_dir, spreadsheet_name):
+        file_path = path.join(submission_dir, spreadsheet_name)
+        index = 0
+        while path.exists(file_path):
+            file_path = path.join(submission_dir, f'{spreadsheet_name}{index}.xlsx')
+            index += 1
+        return file_path
 
     def retrieve(self, submission_uuid):
         try:

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -20,28 +20,13 @@ class SpreadsheetStorageService:
         :param spreadsheet_blob:
         :return:
         """
-        submission_dir = path.join(self.storage_dir, submission_uuid)
-        if not path.exists(submission_dir):
-            os.mkdir(submission_dir)
         try:
-            file_path = self._determine_file_path(submission_dir, spreadsheet_name)
-            storage_manifest_path = path.join(submission_dir, self.storage_manifest_name)
+            file_path = path.join(self.storage_dir, f'{submission_uuid}.xlsx')
             with open(file_path, "wb") as spreadsheet_file:
                 spreadsheet_file.write(spreadsheet_blob)
-                with open(storage_manifest_path, "w") as storage_manfiest:
-                    json.dump({"name": spreadsheet_name, "location": file_path}, storage_manfiest)
-                    return file_path
+                return file_path
         except FileExistsError:
             raise SubmissionSpreadsheetAlreadyExists()
-
-    @staticmethod
-    def _determine_file_path(submission_dir, spreadsheet_name):
-        file_path = path.join(submission_dir, spreadsheet_name)
-        index = 0
-        while path.exists(file_path):
-            file_path = path.join(submission_dir, f'{spreadsheet_name}{index}.xlsx')
-            index += 1
-        return file_path
 
     def retrieve(self, submission_uuid):
         try:

--- a/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
+++ b/broker/service/spreadsheet_storage/spreadsheet_storage_service.py
@@ -1,8 +1,6 @@
-import os
-import json
 from os import path
 
-from .spreadsheet_storage_exceptions import SubmissionSpreadsheetAlreadyExists, SubmissionSpreadsheetDoesntExist
+from .spreadsheet_storage_exceptions import SubmissionSpreadsheetAlreadyExists
 
 
 class SpreadsheetStorageService:
@@ -11,6 +9,7 @@ class SpreadsheetStorageService:
         self.storage_dir = storage_dir
         self.storage_manifest_name = storage_manifest_name
 
+    # TODO remove spreadsheet_name
     def store(self, submission_uuid, spreadsheet_name, spreadsheet_blob):
         """
         Stores a given spreadsheet at path <submission_uuid>/<spreadsheetname>, local to
@@ -29,30 +28,9 @@ class SpreadsheetStorageService:
             raise SubmissionSpreadsheetAlreadyExists()
 
     def retrieve(self, submission_uuid):
-        try:
-            spreadsheet_location = self.get_spreadsheet_location(submission_uuid)
-            spreadsheet_name = spreadsheet_location["name"]
-            spreadsheet_path = spreadsheet_location["path"]
-            with open(spreadsheet_path, "rb") as spreadsheet_file:
-                spreadsheet_blob = spreadsheet_file.read()
-                return {"name": spreadsheet_name, "blob": spreadsheet_blob}
-        except SubmissionSpreadsheetDoesntExist as e:
-            raise e
-
-    def get_spreadsheet_location(self, submission_uuid):
-        submission_dir_path = f'{self.storage_dir}/{submission_uuid}'
-        storage_manifest_path = f'{submission_dir_path}/{self.storage_manifest_name}'
-        if not os.path.isdir(submission_dir_path):
-            raise SubmissionSpreadsheetDoesntExist()
-        else:
-            if not os.path.isfile(storage_manifest_path):
-                raise SubmissionSpreadsheetDoesntExist()
-            else:
-                with open(storage_manifest_path, "rb") as storage_manifest_file:
-                    storage_manifest = json.load(storage_manifest_file)
-                    spreadsheet_name = storage_manifest["name"]
-                    spreadsheet_path = storage_manifest["location"]
-                    if not os.path.isfile(spreadsheet_path):
-                        raise SubmissionSpreadsheetDoesntExist()
-                    else:
-                        return {"name": spreadsheet_name, "path": spreadsheet_path}
+        file_path = path.join(self.storage_dir, f'{submission_uuid}.xlsx')
+        file_manifest = {'name': file_path}
+        with open(file_path, 'rb') as spreadsheet_file:
+            data = spreadsheet_file.read()
+            file_manifest['blob'] = data
+        return file_manifest

--- a/test/brokerapi/test_broker_app.py
+++ b/test/brokerapi/test_broker_app.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from broker.brokerapi import broker_api
 from broker.brokerapi.broker_api import app
 
+
 class BrokerAppTest(TestCase):
 
     def setUp(self):
@@ -27,3 +28,4 @@ class BrokerAppTest(TestCase):
 
             # then:
             self.assertEqual(500, response.status_code)
+

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -1,17 +1,11 @@
 import os
-import shutil
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from broker.service.spreadsheet_storage.spreadsheet_storage_service import SpreadsheetStorageService
 
-TEST_STORAGE_DIR = "test_storage_dir"
-
 
 class SpreadsheetStorageServiceTest(TestCase):
-
-    def setUp(self):
-        os.mkdir(TEST_STORAGE_DIR)
 
     def test_store_spreadsheet(self):
         with TemporaryDirectory() as storage_root:
@@ -36,20 +30,17 @@ class SpreadsheetStorageServiceTest(TestCase):
             self.assertTrue(file_name in spreadsheet_files)
 
     def test_retrieve_spreadsheet(self):
-        test_storage_dir = "test_storage_dir"
-        mock_submission_uuid = "mock-uuid"
-        mock_spreadsheet_name = "mock_spreadsheet.xls"
-        mock_spreadsheet_blob = bytes.fromhex('6d6f636b64617461')
-        spreadsheet_storage_service = SpreadsheetStorageService(test_storage_dir)
+        with TemporaryDirectory() as test_storage_dir:
+            # given:
+            submission_uuid = "8e9602a9-b619-4593-ae68-3cc0f2cdf729"
+            file_name = "spreadsheet.xls"
+            spreadsheet_data = bytes.fromhex('6d6f636b64617461')
+            spreadsheet_storage_service = SpreadsheetStorageService(test_storage_dir)
 
-        try:
-            spreadsheet_storage_service.store(mock_submission_uuid, mock_spreadsheet_name,
-                                              mock_spreadsheet_blob)
-            spreadsheet = spreadsheet_storage_service.retrieve(mock_submission_uuid)
-            assert spreadsheet["name"] == mock_spreadsheet_name
-            assert spreadsheet["blob"] == mock_spreadsheet_blob
-        except Exception as e:
-            assert False
+            # when:
+            spreadsheet_storage_service.store(submission_uuid, file_name, spreadsheet_data)
+            spreadsheet = spreadsheet_storage_service.retrieve(submission_uuid)
 
-    def tearDown(self):
-        shutil.rmtree(TEST_STORAGE_DIR)
+            # then:
+            self.assertEqual(file_name, spreadsheet['name'])
+            self.assertEqual(spreadsheet_data, spreadsheet['blob'])

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -54,12 +54,10 @@ class SpreadsheetStorageServiceTest(TestCase):
 
             # and:
             submission_uuid = "78451f36-c782-4d2d-8491-47e06ddb860f"
-            file_name = "test_spreadsheet.xls"
-            spreadsheet_data = bytes.fromhex('6d6f636b64617461')
+            spreadsheet_data = b'spreadsheet_data'
 
             # when:
-            file_path = spreadsheet_storage_service.store(submission_uuid, file_name,
-                                                          spreadsheet_data)
+            file_path = spreadsheet_storage_service.store(submission_uuid, spreadsheet_data)
 
             # then:
             excel_files = _as_test_dir(storage_root).list_files(ends_with='.xlsx')
@@ -72,8 +70,7 @@ class SpreadsheetStorageServiceTest(TestCase):
             # given:
             storage = SpreadsheetStorageService(storage_root)
             submission_uuid = '44858abe-3d6a-4e86-aeed-0eb5891da6cf'
-            file_name = 'submission.xlsx'
-            storage.store(submission_uuid, file_name, b'spreadsheet')
+            storage.store(submission_uuid, b'spreadsheet')
 
             # and: assume file is stored
             spreadsheet_directory = _as_test_dir(storage_root)
@@ -81,7 +78,7 @@ class SpreadsheetStorageServiceTest(TestCase):
 
             # when: upload the same file again
             updated_data = b'updated_spreadsheet'
-            file_path = storage.store(submission_uuid, file_name, updated_data)
+            file_path = storage.store(submission_uuid, updated_data)
 
             # then:
             with open(file_path, 'rb') as stored_file:

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -38,6 +38,7 @@ class SpreadsheetStorageServiceTest(TestCase):
             submission_uuid = "78451f36-c782-4d2d-8491-47e06ddb860f"
             file_name = "test_spreadsheet.xls"
             spreadsheet_data = bytes.fromhex('6d6f636b64617461')
+            print()
 
             # when:
             spreadsheet_storage_service.store(submission_uuid, file_name, spreadsheet_data)
@@ -50,6 +51,23 @@ class SpreadsheetStorageServiceTest(TestCase):
             # and:
             spreadsheet_files = os.listdir(spreadsheet_directory)
             self.assertTrue(file_name in spreadsheet_files)
+
+    def test_store_updated_spreadsheet(self):
+        with TemporaryDirectory() as storage_root:
+            # given:
+            storage = SpreadsheetStorageService(storage_root)
+            submission_uuid = '44858abe-3d6a-4e86-aeed-0eb5891da6cf'
+            file_name = 'submission.xlsx'
+            storage.store(submission_uuid, file_name, b'spreadsheet')
+
+            # when: upload the same file again
+            storage.store(submission_uuid, file_name, b'updated_spreadsheet')
+
+            # then:
+            spreadsheet_directory = path.join(storage_root, submission_uuid)
+            spreadsheet_files = os.listdir(spreadsheet_directory)
+            self.assertEqual(2, len(spreadsheet_files))
+
 
     def test_retrieve_spreadsheet(self):
         with TemporaryDirectory() as test_storage_dir:

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -4,6 +4,8 @@ from tempfile import TemporaryDirectory
 from tempfile import TemporaryFile
 from unittest import TestCase
 
+from broker.service.spreadsheet_storage.spreadsheet_storage_exceptions import \
+    SubmissionSpreadsheetDoesntExist
 from broker.service.spreadsheet_storage.spreadsheet_storage_service import SpreadsheetStorageService
 
 
@@ -103,3 +105,12 @@ class SpreadsheetStorageServiceTest(TestCase):
             # then:
             self.assertEqual(file_path, file_manifest.get('name'))
             self.assertEqual(spreadsheet_data, file_manifest.get('blob'))
+
+    def test_retrieve_non_existent_spreadsheet(self):
+        with TemporaryDirectory() as storage_dir:
+            # given:
+            storage = SpreadsheetStorageService(storage_dir)
+
+            # expect:
+            self.assertRaises(SubmissionSpreadsheetDoesntExist, storage.retrieve,
+                              'd99bf112-b10c-450d-97d7-5359a31065b5')

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -1,11 +1,9 @@
 import os
 import shutil
-
-
+from tempfile import TemporaryDirectory
 from unittest import TestCase
-from broker.service.spreadsheet_storage.spreadsheet_storage_service import SpreadsheetStorageService
-from broker.service.spreadsheet_storage.spreadsheet_storage_exceptions import SubmissionSpreadsheetDoesntExist, SubmissionSpreadsheetAlreadyExists
 
+from broker.service.spreadsheet_storage.spreadsheet_storage_service import SpreadsheetStorageService
 
 TEST_STORAGE_DIR = "test_storage_dir"
 
@@ -16,17 +14,26 @@ class SpreadsheetStorageServiceTest(TestCase):
         os.mkdir(TEST_STORAGE_DIR)
 
     def test_store_spreadsheet(self):
-        test_storage_dir = "test_storage_dir"
-        mock_submission_uuid = "mock-uuid"
-        mock_spreadsheet_name = "mock_spreadsheet.xls"
-        mock_spreadsheet_blob = bytes.fromhex('6d6f636b64617461')
-        spreadsheet_storage_service = SpreadsheetStorageService(test_storage_dir)
+        with TemporaryDirectory() as storage_root:
+            # given:
+            spreadsheet_storage_service = SpreadsheetStorageService(storage_root)
 
-        try:
-            spreadsheet_storage_service.store(mock_submission_uuid, mock_spreadsheet_name, mock_spreadsheet_blob)
-            assert True
-        except Exception as e:
-            assert False
+            # and:
+            submission_uuid = "78451f36-c782-4d2d-8491-47e06ddb860f"
+            file_name = "test_spreadsheet.xls"
+            spreadsheet_data = bytes.fromhex('6d6f636b64617461')
+
+            # when:
+            spreadsheet_storage_service.store(submission_uuid, file_name, spreadsheet_data)
+
+            # then:
+            spreadsheet_directory = f'{storage_root}/{submission_uuid}'
+            self.assertTrue('Spreadsheet directory does not exist.',
+                            os.path.exists(spreadsheet_directory))
+
+            # and:
+            spreadsheet_files = os.listdir(spreadsheet_directory)
+            self.assertTrue(file_name in spreadsheet_files)
 
     def test_retrieve_spreadsheet(self):
         test_storage_dir = "test_storage_dir"
@@ -36,7 +43,8 @@ class SpreadsheetStorageServiceTest(TestCase):
         spreadsheet_storage_service = SpreadsheetStorageService(test_storage_dir)
 
         try:
-            spreadsheet_storage_service.store(mock_submission_uuid, mock_spreadsheet_name, mock_spreadsheet_blob)
+            spreadsheet_storage_service.store(mock_submission_uuid, mock_spreadsheet_name,
+                                              mock_spreadsheet_blob)
             spreadsheet = spreadsheet_storage_service.retrieve(mock_submission_uuid)
             assert spreadsheet["name"] == mock_spreadsheet_name
             assert spreadsheet["blob"] == mock_spreadsheet_blob

--- a/test/service/test_spreadsheet_storage_service.py
+++ b/test/service/test_spreadsheet_storage_service.py
@@ -44,9 +44,9 @@ class SpreadsheetStorageServiceTest(TestCase):
             spreadsheet_storage_service.store(submission_uuid, file_name, spreadsheet_data)
 
             # then:
-            spreadsheet_directory = f'{storage_root}/{submission_uuid}'
+            spreadsheet_directory = path.join(storage_root, submission_uuid)
             self.assertTrue('Spreadsheet directory does not exist.',
-                            os.path.exists(spreadsheet_directory))
+                            path.exists(spreadsheet_directory))
 
             # and:
             spreadsheet_files = os.listdir(spreadsheet_directory)
@@ -67,7 +67,6 @@ class SpreadsheetStorageServiceTest(TestCase):
             spreadsheet_directory = path.join(storage_root, submission_uuid)
             spreadsheet_files = os.listdir(spreadsheet_directory)
             self.assertEqual(2, len(spreadsheet_files))
-
 
     def test_retrieve_spreadsheet(self):
         with TemporaryDirectory() as test_storage_dir:


### PR DESCRIPTION
I did a bit of restructuring in this PR so that the spreadsheet data is kept up to date every time a new version is submitted. As discussed, we are aware of some of the potential risks involved in this implementation (e.g. data corruption due to concurrent access, etc.) but the probability of the pre-conditions for those risks to occur are perceived to be low considering the feature is currently pretty much in its alpha stages.